### PR TITLE
Exclude extracted images files

### DIFF
--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
An images folder is enforced for the program to run properly, but the
extracted images are excluded and left to each user to properly unzip
into the folder.
