### PR TITLE
Update outputlink to use perceptron links

### DIFF
--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
 import neuralNetwork.OutputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class HiddenOutputPerceptronIntegrationTest {
@@ -38,16 +39,22 @@ public class HiddenOutputPerceptronIntegrationTest {
 		output2.addInput(hidden1);
 		output2.addInput(hidden2);
 		
-		hidden1.addOutputLink(output1);
-		hidden1.addOutputLink(output2);
-		hidden2.addOutputLink(output1);
-		hidden2.addOutputLink(output2);
+		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, -1);
+		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, 1);
+		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		
+		hidden1.addOutputLink(link1a);
+		hidden1.addOutputLink(link1b);
+		hidden2.addOutputLink(link2a);
+		hidden2.addOutputLink(link2b);
 		
 		activateAllInOrder();
 	}
 
 	@Test
 	public void activationsPropagateCorrectOutputs() {
+		// TODO: Use different weights
 		final double expectedOutput1 = 0.6313198;
 		final double expectedOutput2 = 0.3686807;
 		assertEquals(expectedOutput1, hidden1.output(), DELTA);

--- a/HiddenPerceptronTest.java
+++ b/HiddenPerceptronTest.java
@@ -4,10 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
+import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 public class HiddenPerceptronTest {
 
 	private final double DELTA = 0.001;
+	private final Perceptron mockP = new MockPerceptron();
 	
 	private HiddenPerceptron testP;
 	
@@ -15,10 +18,12 @@ public class HiddenPerceptronTest {
 	public void setup()
 	{
 		testP = new HiddenPerceptron(new MockWeightGenerator());
-		testP.addInputLink(new MockPerceptron());
-		testP.addInputLink(new MockPerceptron());
-		testP.addOutputLink(new MockPerceptron());
-		testP.addOutputLink(new MockPerceptron());
+		testP.addInputLink(mockP);
+		testP.addInputLink(mockP);
+		
+		PerceptronLink link1 = new PerceptronLink(testP, mockP, 1);
+		testP.addOutputLink(link1);
+		testP.addOutputLink(link1);
 	}
 	
 	@Test

--- a/InputHiddenPerceptronIntegrationTest.java
+++ b/InputHiddenPerceptronIntegrationTest.java
@@ -5,12 +5,14 @@ import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
 import neuralNetwork.InputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class InputHiddenPerceptronIntegrationTest {
 
 	private final double DELTA = 0.001;
 	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	private final MockPerceptron mockP = new MockPerceptron();
 	
 	private InputPerceptron input1;
 	private InputPerceptron input2;
@@ -34,15 +36,15 @@ public class InputHiddenPerceptronIntegrationTest {
 		hidden2.addInputLink(input1);
 		hidden2.addInputLink(input2);
 		
-		/*
-		 *  Hidden perceptrons are wired to mock perceptrons
-		 *  in this way to avoid creating 0 error due to
-		 *  the alternating weight generator.
-		 */
-		hidden1.addOutputLink(new MockPerceptron());
-		hidden2.addOutputLink(new MockPerceptron());
-		hidden1.addOutputLink(new MockPerceptron());
-		hidden2.addOutputLink(new MockPerceptron());
+		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, -1);
+		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		
+		hidden1.addOutputLink(link1a);
+		hidden1.addOutputLink(link1b);
+		hidden2.addOutputLink(link2a);
+		hidden2.addOutputLink(link2b);
 		
 		activateAllInOrder();
 		calculateAllErrorsInOrder();

--- a/OutputLinkTest.java
+++ b/OutputLinkTest.java
@@ -1,45 +1,64 @@
 import static org.junit.Assert.*;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.OutputLink;
+import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 public class OutputLinkTest {
 
-	static final double DELTA = 0.1;
+	private final double DELTA = 0.1;
+	private final Perceptron mockP = new MockPerceptron();
+	
+	private OutputLink testLinks;
+	private Perceptron sourceP = new MockPerceptron();
+	
+	@Before
+	public void setup()
+	{
+		testLinks = new OutputLink(sourceP);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNull()
+	{
+		testLinks = new OutputLink(null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addLinkHandlesNull()
+	{
+		testLinks.addLink(null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addLinkChecksForCorrectFromPerceptron()
+	{
+		PerceptronLink testLink = new PerceptronLink(mockP, mockP, 0);
+		testLinks.addLink(testLink);
+	}
 	
 	@Test
-	public void getAssociatedErrorNoLinks() {
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		
-		final double error = testLink.getAssociatedError();
+	public void getTotalErrorCalculatesCorrectlyWithNoLinks()
+	{
+		final double error = testLinks.getTotalError();
 		final double expectedError = 0;
 		assertEquals(expectedError, error, DELTA);
 	}
 	
 	@Test
-	public void getAssociatedErrorSingleLink()
+	public void getTotalErrorCalculateCorrectlyWithLinks()
 	{
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		testLink.addLink(new MockPerceptron());
+		PerceptronLink link1 = new PerceptronLink(sourceP, mockP, 0.9);
+		PerceptronLink link2 = new PerceptronLink(sourceP, mockP, 0.3);
 		
-		final double error = testLink.getAssociatedError();
-		final double expectedError = 0.5;
-		assertEquals(expectedError, error, DELTA);
-	}
-	
-	@Test
-	public void getAssociatedErrorMultipleLink()
-	{
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		for(int i = 0; i < 3; i++)
-		{
-			testLink.addLink(new MockPerceptron());
-		}
+		testLinks.addLink(link1);
+		testLinks.addLink(link2);
 		
-		final double error = testLink.getAssociatedError();
-		final double expectedError = 1.5;
-		assertEquals(expectedError, error, DELTA);
+		final double expectedError = 0.6;
+		assertEquals(expectedError, testLinks.getTotalError(), DELTA);
 	}
 
 }

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -38,7 +38,7 @@ public class HiddenPerceptron implements Perceptron
 	@Override
 	public void calculateError()
 	{
-		error = outputLinks.getAssociatedError();
+		error = outputLinks.getTotalError();
 	}
 	
 	@Override

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -22,7 +22,7 @@ public class HiddenPerceptron implements Perceptron
 			throw new IllegalArgumentException("Cannot have a null weight generator.");
 		}
 		inputLinks = new InputLinks(wg);
-		outputLinks = new OutputLink(wg);
+		outputLinks = new OutputLink(this);
 	}
 
 	/*
@@ -67,12 +67,12 @@ public class HiddenPerceptron implements Perceptron
 		inputLinks.addLinkFrom(p);
 	}
 	
-	public void addOutputLink(Perceptron p)
+	public void addOutputLink(PerceptronLink l)
 	{
-		if(p == null)
+		if(l == null)
 		{
 			throw new IllegalArgumentException("Cannot add output to a null.");
 		}
-		outputLinks.addLink(p);
+		outputLinks.addLink(l);
 	}
 }

--- a/neuralNetwork/OutputLink.java
+++ b/neuralNetwork/OutputLink.java
@@ -10,28 +10,28 @@ import java.util.ArrayList;
  */
 public class OutputLink {
 
-	private WeightGenerator weightGen;
-	private ArrayList<Perceptron> outputs;
-	private ArrayList<Double> weights;
-	private int size;
+	private Perceptron source;
+	private ArrayList<PerceptronLink> links;
 	
-	public OutputLink(WeightGenerator wg)
+	public OutputLink(Perceptron source)
 	{
-		weightGen = wg;
-		outputs = new ArrayList<Perceptron>();
-		weights = new ArrayList<Double>();
-		size = 0;
+		if(source == null)
+		{
+			throw new IllegalArgumentException("Cannot have a null source.");
+		}
+		this.source = source;
+		links = new ArrayList<PerceptronLink>();
 	}
 	
 	/*
 	 * Returns the total error associated with these links.
 	 */
-	public double getAssociatedError()
+	public double getTotalError()
 	{
 		double error = 0;
-		for(int i = 0; i < size; i++)
+		for(PerceptronLink l : links)
 		{
-			error += outputs.get(i).error() * weights.get(i);
+			error += l.weightedError();
 		}
 		return error;
 	}
@@ -39,11 +39,17 @@ public class OutputLink {
 	/*
 	 * Introduces a new link to the OutputLink.
 	 */
-	public void addLink(Perceptron newOutput)
+	public void addLink(PerceptronLink newOutputLink)
 	{
-		outputs.add(newOutput);
-		weights.add(weightGen.nextWeight());
-		size++;
+		if(newOutputLink == null)
+		{
+			throw new IllegalArgumentException("Cannot add a null link.");
+		}
+		if(newOutputLink.from() != source)
+		{
+			throw new IllegalArgumentException("Cannot add a link from a different source.");
+		}
+		links.add(newOutputLink);
 	}
 	
 }

--- a/neuralNetwork/PerceptronLink.java
+++ b/neuralNetwork/PerceptronLink.java
@@ -34,12 +34,12 @@ public class PerceptronLink {
 	
 	public double weightedOutput()
 	{
-		return weight * to.output();
+		return weight * from.output();
 	}
 	
 	public double weightedError()
 	{
-		return weight * from.error();
+		return weight * to.error();
 	}
 	
 }


### PR DESCRIPTION
In order to share the weight between perceptrons, input links and
output links must be created through a perceptron link. This change has
created problems in HiddenLayer.
