### PR TITLE
Add Perceptron integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ OutputLayerTest.class
 >>>>>>> master
 =======
 >>>>>>> master
+/InputOutputIntegrationTest.class
+/InputOutputPerceptronIntegrationTest.class
+/AlternatingMockWeightGenerator.class

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ OutputLayerTest.class
 /InputOutputIntegrationTest.class
 /InputOutputPerceptronIntegrationTest.class
 /AlternatingMockWeightGenerator.class
+/InputHiddenPerceptronIntegrationTest.class
+/HiddenOutputPerceptronIntegrationTest.class

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ OutputLayerTest.class
 /InputHiddenPerceptronIntegrationTest.class
 /HiddenOutputPerceptronIntegrationTest.class
 /PerceptronLinkTest.class
+/HiddenHiddenPerceptronIntegrationTest.class

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ OutputLayerTest.class
 /AlternatingMockWeightGenerator.class
 /InputHiddenPerceptronIntegrationTest.class
 /HiddenOutputPerceptronIntegrationTest.class
+/PerceptronLinkTest.class

--- a/AlternatingMockWeightGenerator.java
+++ b/AlternatingMockWeightGenerator.java
@@ -1,0 +1,15 @@
+import neuralNetwork.WeightGenerator;
+
+/*
+ * Returns nextWeight alternating between +1 and -1, starting with +1.
+ */
+public class AlternatingMockWeightGenerator implements WeightGenerator {
+
+	private boolean toggle;
+	
+	@Override
+	public double nextWeight() {
+		return (toggle = !toggle) ? 1 : -1;
+	}
+
+}

--- a/HiddenHiddenPerceptronIntegrationTest.java
+++ b/HiddenHiddenPerceptronIntegrationTest.java
@@ -1,0 +1,129 @@
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import neuralNetwork.HiddenPerceptron;
+import neuralNetwork.PerceptronLink;
+import neuralNetwork.WeightGenerator;
+
+public class HiddenHiddenPerceptronIntegrationTest {
+
+	private final MockPerceptron mockP = new MockPerceptron();
+	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	private final double DELTA = 0.001;
+	
+	private HiddenPerceptron hidden1;
+	private HiddenPerceptron hidden2;
+	private HiddenPerceptron hidden3;
+	private HiddenPerceptron hidden4;
+	
+	@Before
+	public void setUp()
+	{
+		hidden1 = new HiddenPerceptron(wg);
+		hidden2 = new HiddenPerceptron(wg);
+		hidden3 = new HiddenPerceptron(wg);
+		hidden4 = new HiddenPerceptron(wg);
+		
+		PerceptronLink mock1ToHidden1 = new PerceptronLink(mockP, hidden1, 0.7);
+		PerceptronLink mock2ToHidden1 = new PerceptronLink(mockP, hidden1, 0.3);
+		PerceptronLink mock1ToHidden2 = new PerceptronLink(mockP, hidden2, -0.5);
+		PerceptronLink mock2ToHidden2 = new PerceptronLink(mockP, hidden2, -0.3);
+		
+		PerceptronLink hidden1ToHidden3 = new PerceptronLink(hidden1, hidden3, -0.5);
+		PerceptronLink hidden2ToHidden3 = new PerceptronLink(hidden2, hidden3, 0.5);
+		PerceptronLink hidden1ToHidden4 = new PerceptronLink(hidden1, hidden4, 0.6);
+		PerceptronLink hidden2ToHidden4 = new PerceptronLink(hidden2, hidden4, -0.7);
+		
+		PerceptronLink hidden3ToMock3 = new PerceptronLink(hidden3, mockP, 0.3);
+		PerceptronLink hidden3ToMock4 = new PerceptronLink(hidden3, mockP, 0.4);
+		PerceptronLink hidden4ToMock3 = new PerceptronLink(hidden4, mockP, 0.5);
+		PerceptronLink hidden4ToMock4 = new PerceptronLink(hidden4, mockP, 0.6);
+		
+		hidden1.addInputLink(mock1ToHidden1);
+		hidden1.addInputLink(mock2ToHidden1);
+		hidden2.addInputLink(mock1ToHidden2);
+		hidden2.addInputLink(mock2ToHidden2);
+		
+		hidden1.addOutputLink(hidden1ToHidden3);
+		hidden1.addOutputLink(hidden1ToHidden4);
+		hidden2.addOutputLink(hidden2ToHidden3);
+		hidden2.addOutputLink(hidden2ToHidden4);
+		
+		hidden3.addInputLink(hidden1ToHidden3);
+		hidden3.addInputLink(hidden2ToHidden3);
+		hidden4.addInputLink(hidden1ToHidden4);
+		hidden4.addInputLink(hidden2ToHidden4);
+		
+		hidden3.addOutputLink(hidden3ToMock3);
+		hidden3.addOutputLink(hidden3ToMock4);
+		hidden4.addOutputLink(hidden4ToMock3);
+		hidden4.addOutputLink(hidden4ToMock4);
+		
+		activateAllInOrder();
+		calculateAllErrorsInOrder();
+	}
+
+	@Test
+	public void activationsPropagateCorrectOutputs() {
+		final double expectedH1Output = 0.8175745;
+		final double expectedH2Output = 0.197816;
+		assertEquals(expectedH1Output, hidden1.output(), DELTA);
+		assertEquals(expectedH2Output, hidden2.output(), DELTA);
+		
+		final double expectedH3Output = 0.6659938;
+		final double expectedH4Output = 0.342457;
+		assertEquals(expectedH3Output, hidden3.output(), DELTA);
+		assertEquals(expectedH4Output, hidden4.output(), DELTA);
+	}
+	
+	@Test
+	public void errorCalculationsProduceCorrectError()
+	{
+		final double expectedH3Error = 0.35;
+		final double expectedH4Error = 0.55;
+		assertEquals(expectedH3Error, hidden3.error(), DELTA);
+		assertEquals(expectedH4Error, hidden4.error(), DELTA);
+		
+		final double expectedH1Error = 0.155;
+		final double expectedH2Error = -0.21;
+		assertEquals(expectedH1Error, hidden1.error(), DELTA);
+		assertEquals(expectedH2Error, hidden2.error(), DELTA);
+	}
+	
+	@Test
+	public void adjustToErrorCorrectlyAdjustsWeights()
+	{
+		adjustAllToErrors();
+		activateAllInOrder();
+		final double expectedH1Output = 0.8213235;
+		
+		assertEquals(expectedH1Output, hidden1.output(), DELTA);
+	}
+	
+	private void activateAllInOrder()
+	{
+		hidden1.activate();
+		hidden2.activate();
+		hidden3.activate();
+		hidden4.activate();
+	}
+	
+	private void calculateAllErrorsInOrder()
+	{
+		hidden4.calculateError();
+		hidden3.calculateError();
+		hidden2.calculateError();
+		hidden1.calculateError();
+	}
+	
+	private void adjustAllToErrors()
+	{
+		hidden1.adjustToError();
+		hidden2.adjustToError();
+		hidden3.adjustToError();
+		hidden4.adjustToError();
+	}
+
+}

--- a/HiddenLayerTest.java
+++ b/HiddenLayerTest.java
@@ -59,7 +59,7 @@ public class HiddenLayerTest {
 	@Test (expected = IllegalArgumentException.class)
 	public void addPreviousLayerHandlesNull()
 	{
-		testLayer.addPreviousLayer(null);
+		testLayer.appendTo(null);
 	}
 	
 	@Test
@@ -71,8 +71,8 @@ public class HiddenLayerTest {
 		expectedLayers.add(ml1);
 		expectedLayers.add(ml2);
 		
-		testLayer.addPreviousLayer(ml1);
-		testLayer.addPreviousLayer(ml2);
+		testLayer.appendTo(ml1);
+		testLayer.appendTo(ml2);
 		
 		assertEquals(expectedLayers, testLayer.previousLayers());
 	}
@@ -101,7 +101,7 @@ public class HiddenLayerTest {
 	@Test
 	public void activateCorrectlyActivatesAllPerceptrons()
 	{
-		testLayer.addPreviousLayer(new MockLayer(2));
+		testLayer.appendTo(new MockLayer(2));
 		testLayer.activate();
 		
 		double[] expectedOutputs = {0.8807970779, 0.8807970779};
@@ -122,7 +122,7 @@ public class HiddenLayerTest {
 	@Test
 	public void adjustErrorCorrectlyChangesInputs()
 	{
-		testLayer.addPreviousLayer(new MockLayer(2));
+		testLayer.appendTo(new MockLayer(2));
 		testLayer.addNextLayer(new MockLayer(2));
 		testLayer.activate();
 		testLayer.calculateError();

--- a/HiddenLayerTest.java
+++ b/HiddenLayerTest.java
@@ -2,19 +2,17 @@
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.HiddenLayer;
-import neuralNetwork.NetworkLayer;
 import neuralNetwork.Perceptron;
 
 public class HiddenLayerTest {
 
 	private final double DELTA = 0.001;
+	private final MockLayer mockLayer1 = new MockLayer(2);
+	private final MockLayer mockLayer2 = new MockLayer(2);
 	
 	private HiddenLayer testLayer;
 	
@@ -22,6 +20,50 @@ public class HiddenLayerTest {
 	public void setUp()
 	{
 		testLayer = new HiddenLayer(2, new MockWeightGenerator());
+		testLayer.appendTo(mockLayer1);
+		mockLayer2.appendTo(testLayer);
+		testLayer.activate();
+		testLayer.calculateError();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesInvalidSize() {
+		testLayer = new HiddenLayer(0, new MockWeightGenerator());
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNullWeightGenerator() {
+		testLayer = new HiddenLayer(1, null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addPreviousLayerHandlesNull()
+	{
+		testLayer.appendTo(null);
+	}
+	
+	@Test
+	public void activateCorrectlyActivatesAllPerceptrons()
+	{
+		double[] expectedOutputs = {0.8807970779, 0.8807970779};
+		assertArrayEquals(expectedOutputs, getOutputs(), DELTA);
+	}
+	
+	@Test
+	public void calculateErrorCorrectlyCalculatesForAllPerceptrons()
+	{
+		double[] expectedErrors = {1.0, 1.0};
+		assertArrayEquals(expectedErrors, getErrors(), DELTA);
+	}
+	
+	@Test
+	public void adjustErrorCorrectlyChangesInputs()
+	{
+		testLayer.adjustToError();
+		testLayer.activate();
+		
+		double[] expectedOutputs = {0.8980880967, 0.8980880967};
+		assertArrayEquals(expectedOutputs, getOutputs(), DELTA);
 	}
 	
 	private double[] getOutputs()
@@ -44,93 +86,6 @@ public class HiddenLayerTest {
 			errors[i] = perceptrons[i].error();
 		}
 		return errors;
-	}
-
-	@Test (expected = IllegalArgumentException.class)
-	public void constructorHandlesInvalidSize() {
-		testLayer = new HiddenLayer(0, new MockWeightGenerator());
-	}
-	
-	@Test (expected = IllegalArgumentException.class)
-	public void constructorHandlesNullWeightGenerator() {
-		testLayer = new HiddenLayer(1, null);
-	}
-	
-	@Test (expected = IllegalArgumentException.class)
-	public void addPreviousLayerHandlesNull()
-	{
-		testLayer.appendTo(null);
-	}
-	
-	@Test
-	public void getPreviousLayersReturnsCorrectLayers()
-	{
-		MockLayer ml1 = new MockLayer(1);
-		MockLayer ml2 = new MockLayer(1);
-		List<NetworkLayer> expectedLayers = new ArrayList<NetworkLayer>(2);
-		expectedLayers.add(ml1);
-		expectedLayers.add(ml2);
-		
-		testLayer.appendTo(ml1);
-		testLayer.appendTo(ml2);
-		
-		assertEquals(expectedLayers, testLayer.previousLayers());
-	}
-	
-	@Test (expected = IllegalArgumentException.class)
-	public void addNextLayersHandlesNull()
-	{
-		testLayer.addNextLayer(null);
-	}
-	
-	@Test
-	public void getNextLayersReturnsCorrectLayers()
-	{
-		MockLayer ml1 = new MockLayer(1);
-		MockLayer ml2 = new MockLayer(1);
-		List<NetworkLayer> expectedLayers = new ArrayList<NetworkLayer>(2);
-		expectedLayers.add(ml1);
-		expectedLayers.add(ml2);
-		
-		testLayer.addNextLayer(ml1);
-		testLayer.addNextLayer(ml2);
-		
-		assertEquals(expectedLayers, testLayer.nextLayers());
-	}
-	
-	@Test
-	public void activateCorrectlyActivatesAllPerceptrons()
-	{
-		testLayer.appendTo(new MockLayer(2));
-		testLayer.activate();
-		
-		double[] expectedOutputs = {0.8807970779, 0.8807970779};
-		assertArrayEquals(expectedOutputs, getOutputs(), DELTA);
-	}
-	
-	@Test
-	public void calculateErrorCorrectlyCalculatesForAllPerceptrons()
-	{
-		testLayer.addNextLayer(new MockLayer(2));
-		testLayer.activate();
-		testLayer.calculateError();
-		
-		double[] expectedErrors = {1.0, 1.0};
-		assertArrayEquals(expectedErrors, getErrors(), DELTA);
-	}
-	
-	@Test
-	public void adjustErrorCorrectlyChangesInputs()
-	{
-		testLayer.appendTo(new MockLayer(2));
-		testLayer.addNextLayer(new MockLayer(2));
-		testLayer.activate();
-		testLayer.calculateError();
-		testLayer.adjustToError();
-		testLayer.activate();
-		
-		double[] expectedOutputs = {0.8980880967, 0.8980880967};
-		assertArrayEquals(expectedOutputs, getOutputs(), DELTA);
 	}
 
 }

--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -3,17 +3,63 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import neuralNetwork.HiddenPerceptron;
+import neuralNetwork.OutputPerceptron;
+import neuralNetwork.WeightGenerator;
+
 public class HiddenOutputPerceptronIntegrationTest {
 
+	private final double DELTA = 0.001;
+	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	private final MockPerceptron mockP = new MockPerceptron();
+	
+	private HiddenPerceptron hidden1;
+	private HiddenPerceptron hidden2;
+	private OutputPerceptron output1;
+	private OutputPerceptron output2;
+	
+	
 	@Before
 	public void setUp()
 	{
+		hidden1 = new HiddenPerceptron(wg);
+		hidden1.addInputLink(mockP);
+		hidden1.addInputLink(mockP);
 		
+		hidden2 = new HiddenPerceptron(wg);
+		hidden2.addInputLink(mockP);
+		hidden2.addInputLink(mockP);
+		
+		output1 = new OutputPerceptron(wg);
+		output1.addInput(hidden1);
+		output1.addInput(hidden2);
+		
+		output2 = new OutputPerceptron(wg);
+		output2.addInput(hidden1);
+		output2.addInput(hidden2);
+		
+		hidden1.addOutputLink(output1);
+		hidden1.addOutputLink(output2);
+		hidden2.addOutputLink(output1);
+		hidden2.addOutputLink(output2);
+		
+		activateAllInOrder();
 	}
 
 	@Test
-	public void test() {
-		fail("Not yet implemented");
+	public void activationsPropagateCorrectOutputs() {
+		final double expectedOutput1 = 0.6313198;
+		final double expectedOutput2 = 0.3686807;
+		assertEquals(expectedOutput1, hidden1.output(), DELTA);
+		assertEquals(expectedOutput2, hidden2.output(), DELTA);
+	}
+	
+	private void activateAllInOrder()
+	{
+		hidden1.activate();
+		hidden2.activate();
+		output1.activate();
+		output2.activate();
 	}
 
 }

--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -1,0 +1,19 @@
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class HiddenOutputPerceptronIntegrationTest {
+
+	@Before
+	public void setUp()
+	{
+		
+	}
+
+	@Test
+	public void test() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -24,39 +24,42 @@ public class HiddenOutputPerceptronIntegrationTest {
 	public void setUp()
 	{
 		hidden1 = new HiddenPerceptron(wg);
-		hidden1.addInputLink(mockP);
-		hidden1.addInputLink(mockP);
-		
 		hidden2 = new HiddenPerceptron(wg);
-		hidden2.addInputLink(mockP);
-		hidden2.addInputLink(mockP);
-		
 		output1 = new OutputPerceptron(wg);
-		output1.addInput(hidden1);
-		output1.addInput(hidden2);
-		
 		output2 = new OutputPerceptron(wg);
-		output2.addInput(hidden1);
-		output2.addInput(hidden2);
 		
-		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, -1);
-		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
-		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, 1);
-		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		PerceptronLink hidden1ToOutput1 = new PerceptronLink(hidden1, output1, -0.5);
+		PerceptronLink hidden1ToOutput2 = new PerceptronLink(hidden1, output2, 0.5);
+		PerceptronLink hidden2ToOutput1 = new PerceptronLink(hidden2, output1, 0.5);
+		PerceptronLink hidden2ToOutput2 = new PerceptronLink(hidden2, output2, -0.7);
 		
-		hidden1.addOutputLink(link1a);
-		hidden1.addOutputLink(link1b);
-		hidden2.addOutputLink(link2a);
-		hidden2.addOutputLink(link2b);
+		hidden1.addOutputLink(hidden1ToOutput1);
+		hidden1.addOutputLink(hidden1ToOutput2);
+		hidden2.addOutputLink(hidden2ToOutput1);
+		hidden2.addOutputLink(hidden2ToOutput2);
+		
+		output1.addInputLink(hidden1ToOutput1);
+		output1.addInputLink(hidden1ToOutput2);
+		output2.addInputLink(hidden2ToOutput1);
+		output2.addInputLink(hidden2ToOutput2);
+		
+		PerceptronLink inLink1a = new PerceptronLink(hidden1, mockP, 0.7);
+		PerceptronLink inLink1b = new PerceptronLink(hidden1, mockP, 0.3);
+		PerceptronLink inLink2a = new PerceptronLink(hidden2, mockP, -0.5);
+		PerceptronLink inLink2b = new PerceptronLink(hidden2, mockP, -0.3);
+		
+		hidden1.addOutputLink(inLink1a);
+		hidden1.addOutputLink(inLink1b);
+		hidden2.addOutputLink(inLink2a);
+		hidden2.addOutputLink(inLink2b);
 		
 		activateAllInOrder();
 	}
 
 	@Test
 	public void activationsPropagateCorrectOutputs() {
-		// TODO: Use different weights
-		final double expectedOutput1 = 0.6313198;
-		final double expectedOutput2 = 0.3686807;
+		final double expectedOutput1 = 0.6659938;
+		final double expectedOutput2 = 0.242457;
 		assertEquals(expectedOutput1, hidden1.output(), DELTA);
 		assertEquals(expectedOutput2, hidden2.output(), DELTA);
 	}

--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -28,8 +28,18 @@ public class HiddenOutputPerceptronIntegrationTest {
 		output1 = new OutputPerceptron(wg);
 		output2 = new OutputPerceptron(wg);
 		
+		PerceptronLink mock1ToHidden1 = new PerceptronLink(mockP, hidden1, 0.7);
+		PerceptronLink mock2ToHidden1 = new PerceptronLink(mockP, hidden1, 0.3);
+		PerceptronLink mock1ToHidden2 = new PerceptronLink(mockP, hidden2, -0.5);
+		PerceptronLink mock2ToHidden2 = new PerceptronLink(mockP, hidden2, -0.3);
+		
+		hidden1.addInputLink(mock1ToHidden1);
+		hidden1.addInputLink(mock2ToHidden1);
+		hidden2.addInputLink(mock1ToHidden2);
+		hidden2.addInputLink(mock2ToHidden2);
+		
 		PerceptronLink hidden1ToOutput1 = new PerceptronLink(hidden1, output1, -0.5);
-		PerceptronLink hidden1ToOutput2 = new PerceptronLink(hidden1, output2, 0.5);
+		PerceptronLink hidden1ToOutput2 = new PerceptronLink(hidden1, output2, 0.6);
 		PerceptronLink hidden2ToOutput1 = new PerceptronLink(hidden2, output1, 0.5);
 		PerceptronLink hidden2ToOutput2 = new PerceptronLink(hidden2, output2, -0.7);
 		
@@ -39,29 +49,58 @@ public class HiddenOutputPerceptronIntegrationTest {
 		hidden2.addOutputLink(hidden2ToOutput2);
 		
 		output1.addInputLink(hidden1ToOutput1);
-		output1.addInputLink(hidden1ToOutput2);
-		output2.addInputLink(hidden2ToOutput1);
+		output1.addInputLink(hidden2ToOutput1);
+		output2.addInputLink(hidden1ToOutput2);
 		output2.addInputLink(hidden2ToOutput2);
 		
-		PerceptronLink inLink1a = new PerceptronLink(hidden1, mockP, 0.7);
-		PerceptronLink inLink1b = new PerceptronLink(hidden1, mockP, 0.3);
-		PerceptronLink inLink2a = new PerceptronLink(hidden2, mockP, -0.5);
-		PerceptronLink inLink2b = new PerceptronLink(hidden2, mockP, -0.3);
-		
-		hidden1.addOutputLink(inLink1a);
-		hidden1.addOutputLink(inLink1b);
-		hidden2.addOutputLink(inLink2a);
-		hidden2.addOutputLink(inLink2b);
-		
+		output1.setExpectedOutput(1);
+		output2.setExpectedOutput(0);
 		activateAllInOrder();
+		calculateAllErrorsInOrder();
 	}
 
 	@Test
 	public void activationsPropagateCorrectOutputs() {
-		final double expectedOutput1 = 0.6659938;
-		final double expectedOutput2 = 0.242457;
-		assertEquals(expectedOutput1, hidden1.output(), DELTA);
-		assertEquals(expectedOutput2, hidden2.output(), DELTA);
+		final double expectedH1Output = 0.8175745;
+		final double expectedH2Output = 0.197816;
+		assertEquals(expectedH1Output, hidden1.output(), DELTA);
+		assertEquals(expectedH2Output, hidden2.output(), DELTA);
+		
+		final double expectedO1Output = 0.6659938;
+		final double expectedO2Output = 0.342457;
+		assertEquals(expectedO1Output, output1.output(), DELTA);
+		assertEquals(expectedO2Output, output2.output(), DELTA);
+	}
+	
+	@Test
+	public void errorCalculationsProduceCorrectError()
+	{
+		final double expectedO1Error = 0.3340062;
+		final double expectedO2Error = -0.343457;
+		assertEquals(expectedO1Error, output1.error(), DELTA);
+		assertEquals(expectedO2Error, output2.error(), DELTA);
+		
+		final double expectedH1Error = -0.3730773;
+		final double expectedH2Error = 0.407423;
+		assertEquals(expectedH1Error, hidden1.error(), DELTA);
+		assertEquals(expectedH2Error, hidden2.error(), DELTA);
+	}
+	
+	@Test
+	public void adjustToErrorAdjustsWeightsCorrectly()
+	{
+		adjustAllToErrors();
+		activateAllInOrder();
+		
+		final double expectedH1Output = 0.808299;
+		final double expectedH2Output = 0.2003866;
+		assertEquals(expectedH1Output, hidden1.output(), DELTA);
+		assertEquals(expectedH2Output, hidden2.output(), DELTA);
+		
+		final double expectedO1Output = 0.677155;
+		final double expectedO2Output = 0.336488;
+		assertEquals(expectedO1Output, output1.output(), DELTA);
+		assertEquals(expectedO2Output, output2.output(), DELTA);
 	}
 	
 	private void activateAllInOrder()
@@ -70,6 +109,22 @@ public class HiddenOutputPerceptronIntegrationTest {
 		hidden2.activate();
 		output1.activate();
 		output2.activate();
+	}
+	
+	private void calculateAllErrorsInOrder()
+	{
+		output1.calculateError();
+		output2.calculateError();
+		hidden1.calculateError();
+		hidden2.calculateError();
+	}
+	
+	private void adjustAllToErrors()
+	{
+		hidden1.adjustToError();
+		hidden2.adjustToError();
+		output1.adjustToError();
+		output2.adjustToError();
 	}
 
 }

--- a/HiddenOutputPerceptronIntegrationTest.java
+++ b/HiddenOutputPerceptronIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
 import neuralNetwork.OutputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class HiddenOutputPerceptronIntegrationTest {
@@ -38,16 +39,22 @@ public class HiddenOutputPerceptronIntegrationTest {
 		output2.addInput(hidden1);
 		output2.addInput(hidden2);
 		
-		hidden1.addOutputLink(output1);
-		hidden1.addOutputLink(output2);
-		hidden2.addOutputLink(output1);
-		hidden2.addOutputLink(output2);
+		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, -1);
+		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, 1);
+		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		
+		hidden1.addOutputLink(link1a);
+		hidden1.addOutputLink(link1b);
+		hidden2.addOutputLink(link2a);
+		hidden2.addOutputLink(link2b);
 		
 		activateAllInOrder();
 	}
 
 	@Test
 	public void activationsPropagateCorrectOutputs() {
+		// TODO: Use different weights
 		final double expectedOutput1 = 0.6313198;
 		final double expectedOutput2 = 0.3686807;
 		assertEquals(expectedOutput1, hidden1.output(), DELTA);

--- a/HiddenPerceptronTest.java
+++ b/HiddenPerceptronTest.java
@@ -18,12 +18,15 @@ public class HiddenPerceptronTest {
 	public void setup()
 	{
 		testP = new HiddenPerceptron(new MockWeightGenerator());
-		testP.addInputLink(mockP);
-		testP.addInputLink(mockP);
+		PerceptronLink inLink1 = new PerceptronLink(mockP, testP, 1);
+		PerceptronLink inLink2 = new PerceptronLink(mockP, testP, 1);
+		testP.addInputLink(inLink1);
+		testP.addInputLink(inLink2);
 		
-		PerceptronLink link1 = new PerceptronLink(testP, mockP, 1);
-		testP.addOutputLink(link1);
-		testP.addOutputLink(link1);
+		PerceptronLink outLink1 = new PerceptronLink(testP, mockP, 1);
+		PerceptronLink outLink2 = new PerceptronLink(testP, mockP, 1);
+		testP.addOutputLink(outLink1);
+		testP.addOutputLink(outLink2);
 	}
 	
 	@Test

--- a/HiddenPerceptronTest.java
+++ b/HiddenPerceptronTest.java
@@ -4,10 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
+import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 public class HiddenPerceptronTest {
 
 	private final double DELTA = 0.001;
+	private final Perceptron mockP = new MockPerceptron();
 	
 	private HiddenPerceptron testP;
 	
@@ -15,10 +18,12 @@ public class HiddenPerceptronTest {
 	public void setup()
 	{
 		testP = new HiddenPerceptron(new MockWeightGenerator());
-		testP.addInputLink(new MockPerceptron());
-		testP.addInputLink(new MockPerceptron());
-		testP.addOutputLink(new MockPerceptron());
-		testP.addOutputLink(new MockPerceptron());
+		testP.addInputLink(mockP);
+		testP.addInputLink(mockP);
+		
+		PerceptronLink link1 = new PerceptronLink(testP, mockP, 1);
+		testP.addOutputLink(link1);
+		testP.addOutputLink(link1);
 	}
 	
 	@Test

--- a/InputHiddenPerceptronIntegrationTest.java
+++ b/InputHiddenPerceptronIntegrationTest.java
@@ -5,12 +5,14 @@ import org.junit.Test;
 
 import neuralNetwork.HiddenPerceptron;
 import neuralNetwork.InputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class InputHiddenPerceptronIntegrationTest {
 
 	private final double DELTA = 0.001;
 	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	private final MockPerceptron mockP = new MockPerceptron();
 	
 	private InputPerceptron input1;
 	private InputPerceptron input2;
@@ -34,15 +36,15 @@ public class InputHiddenPerceptronIntegrationTest {
 		hidden2.addInputLink(input1);
 		hidden2.addInputLink(input2);
 		
-		/*
-		 *  Hidden perceptrons are wired to mock perceptrons
-		 *  in this way to avoid creating 0 error due to
-		 *  the alternating weight generator.
-		 */
-		hidden1.addOutputLink(new MockPerceptron());
-		hidden2.addOutputLink(new MockPerceptron());
-		hidden1.addOutputLink(new MockPerceptron());
-		hidden2.addOutputLink(new MockPerceptron());
+		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, -1);
+		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		
+		hidden1.addOutputLink(link1a);
+		hidden1.addOutputLink(link1b);
+		hidden2.addOutputLink(link2a);
+		hidden2.addOutputLink(link2b);
 		
 		activateAllInOrder();
 		calculateAllErrorsInOrder();

--- a/InputHiddenPerceptronIntegrationTest.java
+++ b/InputHiddenPerceptronIntegrationTest.java
@@ -1,0 +1,105 @@
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import neuralNetwork.HiddenPerceptron;
+import neuralNetwork.InputPerceptron;
+import neuralNetwork.WeightGenerator;
+
+public class InputHiddenPerceptronIntegrationTest {
+
+	private final double DELTA = 0.001;
+	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	
+	private InputPerceptron input1;
+	private InputPerceptron input2;
+	private HiddenPerceptron hidden1;
+	private HiddenPerceptron hidden2;
+	
+	@Before
+	public void setUp()
+	{
+		input1 = new InputPerceptron();
+		input1.setInput(0.7);
+		
+		input2 = new InputPerceptron();
+		input2.setInput(0.3);
+		
+		hidden1 = new HiddenPerceptron(wg);
+		hidden1.addInputLink(input1);
+		hidden1.addInputLink(input2);
+		
+		hidden2 = new HiddenPerceptron(wg);
+		hidden2.addInputLink(input1);
+		hidden2.addInputLink(input2);
+		
+		/*
+		 *  Hidden perceptrons are wired to mock perceptrons
+		 *  in this way to avoid creating 0 error due to
+		 *  the alternating weight generator.
+		 */
+		hidden1.addOutputLink(new MockPerceptron());
+		hidden2.addOutputLink(new MockPerceptron());
+		hidden1.addOutputLink(new MockPerceptron());
+		hidden2.addOutputLink(new MockPerceptron());
+		
+		activateAllInOrder();
+		calculateAllErrorsInOrder();
+	}
+
+	@Test
+	public void ativationsPropagateCorrectOutputs()
+	{
+		final double expectedOutput1 = 0.645656;
+		final double expectedOutput2 = 0.354344;
+		assertEquals(expectedOutput1, hidden1.output(), DELTA);
+		assertEquals(expectedOutput2, hidden2.output(), DELTA);
+	}
+	
+	@Test
+	public void errorCalculationsProduceCorrectError()
+	{
+		final double expectedError1 = 1.0;
+		final double expectedError2 = -1.0;
+		assertEquals(expectedError1, hidden1.error(), DELTA);
+		assertEquals(expectedError2, hidden2.error(), DELTA);
+	}
+	
+	@Test
+	public void adjustToErrorAdjustsWeightsCorrectly()
+	{
+		adjustAllToErrors();
+		activateAllInOrder();
+		
+		final double expectedOutput1 = 0.674615;
+		final double expectedOutput2 = 0.338302;
+		assertEquals(expectedOutput1, hidden1.output(), DELTA);
+		assertEquals(expectedOutput2, hidden2.output(), DELTA);
+	}
+	
+	private void activateAllInOrder()
+	{
+		input1.activate();
+		input2.activate();
+		hidden1.activate();
+		hidden2.activate();
+	}
+	
+	private void calculateAllErrorsInOrder()
+	{
+		hidden1.calculateError();
+		hidden2.calculateError();
+		input1.calculateError();
+		input2.calculateError();
+	}
+	
+	private void adjustAllToErrors()
+	{
+		input1.adjustToError();
+		input2.adjustToError();
+		hidden1.adjustToError();
+		hidden2.adjustToError();
+	}
+
+}

--- a/InputHiddenPerceptronIntegrationTest.java
+++ b/InputHiddenPerceptronIntegrationTest.java
@@ -29,22 +29,26 @@ public class InputHiddenPerceptronIntegrationTest {
 		input2.setInput(0.3);
 		
 		hidden1 = new HiddenPerceptron(wg);
-		hidden1.addInputLink(input1);
-		hidden1.addInputLink(input2);
+		PerceptronLink inLink1a = new PerceptronLink(input1, hidden1, -1);
+		PerceptronLink inLink1b = new PerceptronLink(input2, hidden1, 1);
+		hidden1.addInputLink(inLink1a);
+		hidden1.addInputLink(inLink1b);
 		
 		hidden2 = new HiddenPerceptron(wg);
-		hidden2.addInputLink(input1);
-		hidden2.addInputLink(input2);
+		PerceptronLink inLink2a = new PerceptronLink(input1, hidden2, 1);
+		PerceptronLink inLink2b = new PerceptronLink(input2, hidden2, -1);
+		hidden2.addInputLink(inLink2a);
+		hidden2.addInputLink(inLink2b);
 		
-		PerceptronLink link1a = new PerceptronLink(hidden1, mockP, 1);
-		PerceptronLink link1b = new PerceptronLink(hidden1, mockP, 1);
-		PerceptronLink link2a = new PerceptronLink(hidden2, mockP, -1);
-		PerceptronLink link2b = new PerceptronLink(hidden2, mockP, -1);
+		PerceptronLink outLink1a = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink outLink1b = new PerceptronLink(hidden1, mockP, 1);
+		PerceptronLink outLink2a = new PerceptronLink(hidden2, mockP, -1);
+		PerceptronLink outLink2b = new PerceptronLink(hidden2, mockP, -1);
 		
-		hidden1.addOutputLink(link1a);
-		hidden1.addOutputLink(link1b);
-		hidden2.addOutputLink(link2a);
-		hidden2.addOutputLink(link2b);
+		hidden1.addOutputLink(outLink1a);
+		hidden1.addOutputLink(outLink1b);
+		hidden2.addOutputLink(outLink2a);
+		hidden2.addOutputLink(outLink2b);
 		
 		activateAllInOrder();
 		calculateAllErrorsInOrder();

--- a/InputHiddenPerceptronIntegrationTest.java
+++ b/InputHiddenPerceptronIntegrationTest.java
@@ -23,32 +23,37 @@ public class InputHiddenPerceptronIntegrationTest {
 	public void setUp()
 	{
 		input1 = new InputPerceptron();
-		input1.setInput(0.7);
-		
 		input2 = new InputPerceptron();
-		input2.setInput(0.3);
-		
 		hidden1 = new HiddenPerceptron(wg);
-		PerceptronLink inLink1a = new PerceptronLink(input1, hidden1, -1);
-		PerceptronLink inLink1b = new PerceptronLink(input2, hidden1, 1);
-		hidden1.addInputLink(inLink1a);
-		hidden1.addInputLink(inLink1b);
-		
 		hidden2 = new HiddenPerceptron(wg);
-		PerceptronLink inLink2a = new PerceptronLink(input1, hidden2, 1);
-		PerceptronLink inLink2b = new PerceptronLink(input2, hidden2, -1);
-		hidden2.addInputLink(inLink2a);
-		hidden2.addInputLink(inLink2b);
 		
+		PerceptronLink input1ToHidden1 = new PerceptronLink(input1, hidden1, -1);
+		PerceptronLink input2ToHidden1 = new PerceptronLink(input2, hidden1, 1);
+		PerceptronLink input1ToHidden2 = new PerceptronLink(input1, hidden2, 1);
+		PerceptronLink input2ToHidden2 = new PerceptronLink(input2, hidden2, -1);
+
 		PerceptronLink outLink1a = new PerceptronLink(hidden1, mockP, 1);
 		PerceptronLink outLink1b = new PerceptronLink(hidden1, mockP, 1);
 		PerceptronLink outLink2a = new PerceptronLink(hidden2, mockP, -1);
 		PerceptronLink outLink2b = new PerceptronLink(hidden2, mockP, -1);
 		
+		input1.addOutputLink(input1ToHidden1);
+		input1.addOutputLink(input2ToHidden1);
+		input2.addOutputLink(input1ToHidden2);
+		input2.addOutputLink(input2ToHidden2);
+		
+		hidden1.addInputLink(input1ToHidden1);
+		hidden1.addInputLink(input2ToHidden1);
+		hidden2.addInputLink(input1ToHidden2);
+		hidden2.addInputLink(input2ToHidden2);
+		
 		hidden1.addOutputLink(outLink1a);
 		hidden1.addOutputLink(outLink1b);
 		hidden2.addOutputLink(outLink2a);
 		hidden2.addOutputLink(outLink2b);
+
+		input1.setInput(0.7);
+		input2.setInput(0.3);
 		
 		activateAllInOrder();
 		calculateAllErrorsInOrder();

--- a/InputLinksTest.java
+++ b/InputLinksTest.java
@@ -2,77 +2,101 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
+import neuralNetwork.WeightGenerator;
 import neuralNetwork.InputLinks;
 
 public class InputLinksTest {
 	
 	final double DELTA = 0.001;
-
-	@Test
-	public void constructorNoArgsCreatesOnlyRandomBias()
+	final Perceptron source = new MockPerceptron();
+	final WeightGenerator wg = new MockWeightGenerator();
+	
+	private InputLinks testLink;
+	
+	@Before
+	public void setup()
 	{
-		InputLinks testLink = new InputLinks();
-		final double biasValue = testLink.inputValue();
-		
-		assertTrue(biasValue >= -1 && biasValue <= 1.0);
+		testLink = new InputLinks(source, wg);
 	}
 	
-	@Test
-	public void constructorOneArgsCreatesOnlyBiasFromWeightGenerator()
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNullSource()
 	{
-		InputLinks testLink = new InputLinks(new MockWeightGenerator());
-		final double actualBiasValue = testLink.inputValue();
-		
-		final double expectedBiasValue = 1;
-		assertEquals(expectedBiasValue, actualBiasValue, DELTA);
+		testLink = new InputLinks(null, wg);
 	}
 	
-	@Test
-	public void constructorTwoArgsCreatesBiasAndAllWeightsFromWeightGenerator()
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNullWeightGenerator()
 	{
-		ArrayList<Perceptron> inputs = new ArrayList<Perceptron>(2);
-		inputs.add(new MockPerceptron());
-		inputs.add(new MockPerceptron());
-		
-		InputLinks testLink = new InputLinks(new MockWeightGenerator(), inputs);
-		
-		final double actualInputValue = testLink.inputValue();
-		
-		final double expectedInputValue = 2.0;
-		assertEquals(expectedInputValue, actualInputValue, DELTA);
+		testLink = new InputLinks(source, null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addLinkHandlesNullLink()
+	{
+		testLink.addLink(null);;
 	}
 	
 	@Test
 	public void adjustToErrorGivenOutputZeroError()
 	{
-		InputLinks testLink = new InputLinks(new MockWeightGenerator());
-		
-		final double expectedInputValue = testLink.inputValue();
+		final double expectedInputValue = testLink.totalInput();
 		testLink.adjustToErrorGivenOutput(0, 1);
-		assertEquals(expectedInputValue, testLink.inputValue(), DELTA);
+		assertEquals(expectedInputValue, testLink.totalInput(), DELTA);
 	}
 	
 	@Test
 	public void adjustToErrorGivenOutputZeroOutput()
 	{
-		InputLinks testLink = new InputLinks(new MockWeightGenerator());
-		
-		final double expectedInputValue = testLink.inputValue();
+		final double expectedInputValue = testLink.totalInput();
 		testLink.adjustToErrorGivenOutput(1, 0);
-		assertEquals(expectedInputValue, testLink.inputValue(), DELTA);
+		assertEquals(expectedInputValue, testLink.totalInput(), DELTA);
 	}
 	
 	@Test
-	public void adjustToErrorGivenOutputCalculations()
+	public void adjustToErrorGivenOutputZeroOutputZeroError()
 	{
-		InputLinks testLink = new InputLinks(new MockWeightGenerator());
+		final double expectedInputValue = testLink.totalInput();
+		testLink.adjustToErrorGivenOutput(0, 0);
+		assertEquals(expectedInputValue, testLink.totalInput(), DELTA);
+	}
+	
+	@Test
+	public void constructorCreatesBias()
+	{
+		final double actualInput = testLink.totalInput();
+		
+		final double expectedInput = 1;
+		assertEquals(expectedInput, actualInput, DELTA);
+	}
+	
+	@Test
+	public void addLinkCorrectlyInsertsALink()
+	{
+		addLinkToMock();
+		final double expectedInput = 1.5;
+		assertEquals(expectedInput, testLink.totalInput(), DELTA);
+	}
+	
+	@Test
+	public void adjustToErrorCorrectlyAdjustsWeights()
+	{
+		addLinkToMock();
 		testLink.adjustToErrorGivenOutput(0.5, 0.5);
 		
-		final double expectedInputValue = 1.025;
-		assertEquals(expectedInputValue, testLink.inputValue(), DELTA);
+		final double expectedInputValue = 1.5375;
+		assertEquals(expectedInputValue, testLink.totalInput(), DELTA);
+	}
+	
+	private void addLinkToMock()
+	{
+		PerceptronLink l = new PerceptronLink(source, new MockPerceptron(), 1);
+		testLink.addLink(l);
 	}
 
 }

--- a/InputOutputPerceptronIntegrationTest.java
+++ b/InputOutputPerceptronIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import neuralNetwork.InputPerceptron;
 import neuralNetwork.OutputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class InputOutputPerceptronIntegrationTest {
@@ -27,13 +28,17 @@ public class InputOutputPerceptronIntegrationTest {
 		input2.setInput(0.3);
 		
 		output1 = new OutputPerceptron(wg);
-		output1.addInput(input1);
-		output1.addInput(input2);
+		PerceptronLink inLink1a = new PerceptronLink(input1, output1, -1);
+		PerceptronLink inLink1b = new PerceptronLink(input2, output1, 1);
+		output1.addInputLink(inLink1a);
+		output1.addInputLink(inLink1b);
 		output1.setExpectedOutput(1.0);
 		
 		output2 = new OutputPerceptron(wg);
-		output2.addInput(input1);
-		output2.addInput(input2);
+		PerceptronLink inLink2a = new PerceptronLink(input1, output2, 1);
+		PerceptronLink inLink2b = new PerceptronLink(input2, output2, -1);
+		output2.addInputLink(inLink2a);
+		output2.addInputLink(inLink2b);
 		output2.setExpectedOutput(0.0);
 		
 		activateAllInOrder();

--- a/InputOutputPerceptronIntegrationTest.java
+++ b/InputOutputPerceptronIntegrationTest.java
@@ -22,23 +22,29 @@ public class InputOutputPerceptronIntegrationTest {
 	public void setUp() 
 	{
 		input1 = new InputPerceptron();
-		input1.setInput(0.7);
-		
 		input2 = new InputPerceptron();
-		input2.setInput(0.3);
-		
 		output1 = new OutputPerceptron(wg);
-		PerceptronLink inLink1a = new PerceptronLink(input1, output1, -1);
-		PerceptronLink inLink1b = new PerceptronLink(input2, output1, 1);
-		output1.addInputLink(inLink1a);
-		output1.addInputLink(inLink1b);
-		output1.setExpectedOutput(1.0);
-		
 		output2 = new OutputPerceptron(wg);
-		PerceptronLink inLink2a = new PerceptronLink(input1, output2, 1);
-		PerceptronLink inLink2b = new PerceptronLink(input2, output2, -1);
-		output2.addInputLink(inLink2a);
-		output2.addInputLink(inLink2b);
+		
+		PerceptronLink input1ToOutput1 = new PerceptronLink(input1, output1, -1);
+		PerceptronLink input2ToOutput1 = new PerceptronLink(input2, output1, 1);
+		PerceptronLink input1ToOutput2 = new PerceptronLink(input1, output2, 1);
+		PerceptronLink input2ToOutput2 = new PerceptronLink(input2, output2, -1);
+		
+		input1.addOutputLink(input1ToOutput1);
+		input1.addOutputLink(input1ToOutput2);
+		input2.addOutputLink(input1ToOutput2);
+		input2.addOutputLink(input2ToOutput2);
+		
+		output1.addInputLink(input1ToOutput1);
+		output1.addInputLink(input2ToOutput1);
+		output2.addInputLink(input1ToOutput2);
+		output2.addInputLink(input2ToOutput2);
+
+		input1.setInput(0.7);
+		input2.setInput(0.3);
+
+		output1.setExpectedOutput(1.0);
 		output2.setExpectedOutput(0.0);
 		
 		activateAllInOrder();

--- a/InputOutputPerceptronIntegrationTest.java
+++ b/InputOutputPerceptronIntegrationTest.java
@@ -89,7 +89,7 @@ public class InputOutputPerceptronIntegrationTest {
 	}
 	
 	@Test
-	public void adjustToErrorChangesOutputsToCorrectNewValues()
+	public void adjustToErrorAdjustsWeightsCorrectly()
 	{
 		adjustAllToError();
 		activateAllInOrder();

--- a/InputOutputPerceptronIntegrationTest.java
+++ b/InputOutputPerceptronIntegrationTest.java
@@ -1,0 +1,115 @@
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import neuralNetwork.InputPerceptron;
+import neuralNetwork.OutputPerceptron;
+import neuralNetwork.WeightGenerator;
+
+public class InputOutputPerceptronIntegrationTest {
+
+	private final double DELTA = 0.001;
+	private final WeightGenerator wg = new AlternatingMockWeightGenerator();
+	
+	private InputPerceptron input1;
+	private InputPerceptron input2;
+	private OutputPerceptron output1;
+	private OutputPerceptron output2;
+	
+	@Before
+	public void setUp() 
+	{
+		input1 = new InputPerceptron();
+		input1.setInput(0.7);
+		
+		input2 = new InputPerceptron();
+		input2.setInput(0.3);
+		
+		output1 = new OutputPerceptron(wg);
+		output1.addInput(input1);
+		output1.addInput(input2);
+		output1.setExpectedOutput(1.0);
+		
+		output2 = new OutputPerceptron(wg);
+		output2.addInput(input1);
+		output2.addInput(input2);
+		output2.setExpectedOutput(0.0);
+		
+		activateAllInOrder();
+		calculateAllErrorsInOrder();
+	}
+	
+	private void activateAllInOrder()
+	{
+		input1.activate();
+		input2.activate();
+		output1.activate();
+		output2.activate();
+	}
+	
+	private void calculateAllErrorsInOrder()
+	{
+		output1.calculateError();
+		output2.calculateError();
+		input1.calculateError();
+		input2.calculateError();
+	}
+	
+	private void adjustAllToError()
+	{
+		input1.adjustToError();
+		input2.adjustToError();
+		output1.adjustToError();
+		output2.adjustToError();
+	}
+	
+	private void adjustOutputsToError()
+	{
+		output1.adjustToError();
+		output2.adjustToError();
+	}
+
+	@Test
+	public void activationsPropagateCorrectOutputs()
+	{
+		final double expectedOutput1 = 0.645656;
+		final double expectedOutput2 = 0.354344;
+		assertEquals(expectedOutput1, output1.output(), DELTA);
+		assertEquals(expectedOutput2, output2.output(), DELTA);
+	}
+	
+	@Test
+	public void errorCalculationsProduceCorrectError()
+	{
+		final double expectedError1 = 0.354344;
+		final double expectedError2 = -0.354344;
+		assertEquals(expectedError1, output1.error(), DELTA);
+		assertEquals(expectedError2, output2.error(), DELTA);
+	}
+	
+	@Test
+	public void adjustToErrorChangesOutputsToCorrectNewValues()
+	{
+		adjustAllToError();
+		activateAllInOrder();
+		final double expectedOutput1 = 0.656053;
+		final double expectedOutput2 = 0.348620;
+		
+		assertEquals(expectedOutput1, output1.output(), DELTA);
+		assertEquals(expectedOutput2, output2.output(), DELTA);
+	}
+	
+	@Test
+	public void inputsDoNotNeedToAdjustToError()
+	{
+		adjustOutputsToError();
+		activateAllInOrder();
+		final double expectedOutput1 = 0.656053;
+		final double expectedOutput2 = 0.348620;
+		
+		assertEquals(expectedOutput1, output1.output(), DELTA);
+		assertEquals(expectedOutput2, output2.output(), DELTA);
+	}
+
+}

--- a/InputPerceptronTest.java
+++ b/InputPerceptronTest.java
@@ -1,5 +1,6 @@
 import static org.junit.Assert.*;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.InputPerceptron;
@@ -8,43 +9,38 @@ public class InputPerceptronTest {
 
 	final double DELTA = 0.001;
 	
+	private InputPerceptron testP;
+	
+	@Before
+	public void setup()
+	{
+		testP = new InputPerceptron();
+		testP.setInput(1.0);
+	}
+	
 	@Test
-	public void activateSetsOutputToInput() {
-		InputPerceptron testPerceptron = new InputPerceptron();
-		final double testInput = 1.0;
-		testPerceptron.setInput(testInput);
-		testPerceptron.activate();
-		
-		assertEquals(testInput, testPerceptron.output(), DELTA);
+	public void setInputChangesOutput() {
+		final double expectedOutput = 1.0;
+		assertEquals(expectedOutput, testP.output(), DELTA);
 	}
 	
 	@Test
 	public void doesNotHaveError()
 	{
-		InputPerceptron testPerceptron = new InputPerceptron();
-		final double testInput = 1.0;
-		testPerceptron.setInput(testInput);
-		testPerceptron.activate();
-		
-		testPerceptron.adjustToError();
+		testP.calculateError();
 		
 		final double expectedError = 0;
-		assertEquals(expectedError, testPerceptron.error(), DELTA);
+		assertEquals(expectedError, testP.error(), DELTA);
 	}
 	
 	@Test
 	public void doesNotAdjustToError()
 	{
-		InputPerceptron testPerceptron = new InputPerceptron();
-		final double testInput = 1.0;
-		testPerceptron.setInput(testInput);
-		testPerceptron.activate();
+		testP.adjustToError();
+		testP.activate();
 		
-		testPerceptron.adjustToError();
-		
-		testPerceptron.activate();
-		
-		assertEquals(testInput, testPerceptron.output(), DELTA);
+		final double expectedOutput = 1.0;
+		assertEquals(expectedOutput, testP.output(), DELTA);
 	}
 
 }

--- a/MockLayer.java
+++ b/MockLayer.java
@@ -1,9 +1,11 @@
 import neuralNetwork.NetworkLayer;
 import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 public class MockLayer implements NetworkLayer {
 
 	private MockPerceptron[] perceptrons;
+	private final MockWeightGenerator wg = new MockWeightGenerator();
 	
 	public MockLayer(int size)
 	{
@@ -35,6 +37,19 @@ public class MockLayer implements NetworkLayer {
 	public Perceptron[] perceptrons()
 	{
 		return perceptrons;
+	}
+
+	@Override
+	public void appendTo(NetworkLayer l) {
+		for(MockPerceptron mockP : perceptrons)
+		{
+			for(Perceptron inputP : l.perceptrons())
+			{
+				PerceptronLink appendingLink = new PerceptronLink(inputP, mockP, wg.nextWeight());
+				inputP.addOutputLink(appendingLink);
+				mockP.addInputLink(appendingLink);
+			}
+		}
 	}
 
 }

--- a/MockPerceptron.java
+++ b/MockPerceptron.java
@@ -1,4 +1,5 @@
 import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 /*
  * A dummy object to test interactions with Perceptrons.
@@ -8,33 +9,28 @@ import neuralNetwork.Perceptron;
 public class MockPerceptron implements Perceptron {
 
 	@Override
-	public void activate() {
-		// TODO Auto-generated method stub
-
-	}
+	public void activate() {}
 
 	@Override
-	public void adjustToError() {
-		// TODO Auto-generated method stub
-
-	}
+	public void adjustToError() {}
 
 	@Override
 	public double output() {
-		// TODO Auto-generated method stub
 		return 0.5;
 	}
 
 	@Override
 	public double error() {
-		// TODO Auto-generated method stub
 		return 0.5;
 	}
 
 	@Override
-	public void calculateError() {
-		// TODO Auto-generated method stub
-		
-	}
+	public void calculateError() {}
+
+	@Override
+	public void addInputLink(PerceptronLink l) {}
+
+	@Override
+	public void addOutputLink(PerceptronLink l) {}
 
 }

--- a/OutputLayerTest.java
+++ b/OutputLayerTest.java
@@ -19,7 +19,7 @@ public class OutputLayerTest {
 	@Before
 	public void setUp() {
 		testLayer = new OutputLayer(2, new MockWeightGenerator());
-		testLayer.addPreviousLayer(new MockLayer(2));
+		testLayer.appendTo(new MockLayer(2));
 	}
 	
 	private double[] getErrors()
@@ -48,7 +48,7 @@ public class OutputLayerTest {
 	@Test (expected = IllegalArgumentException.class)
 	public void addPreviousLayerHandlesNull()
 	{
-		testLayer.addPreviousLayer(null);
+		testLayer.appendTo(null);
 	}
 
 	@Test
@@ -115,8 +115,8 @@ public class OutputLayerTest {
 		expectedLayers.add(previous2);
 		
 		testLayer = new OutputLayer(2, new MockWeightGenerator());
-		testLayer.addPreviousLayer(previous1);
-		testLayer.addPreviousLayer(previous2);
+		testLayer.appendTo(previous1);
+		testLayer.appendTo(previous2);
 		
 		assertEquals(expectedLayers, testLayer.previousLayers());
 	}

--- a/OutputLinkTest.java
+++ b/OutputLinkTest.java
@@ -1,45 +1,64 @@
 import static org.junit.Assert.*;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.OutputLink;
+import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
 
 public class OutputLinkTest {
 
-	static final double DELTA = 0.1;
+	private final double DELTA = 0.1;
+	private final Perceptron mockP = new MockPerceptron();
+	
+	private OutputLink testLinks;
+	private Perceptron sourceP = new MockPerceptron();
+	
+	@Before
+	public void setup()
+	{
+		testLinks = new OutputLink(sourceP);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNull()
+	{
+		testLinks = new OutputLink(null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addLinkHandlesNull()
+	{
+		testLinks.addLink(null);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void addLinkChecksForCorrectFromPerceptron()
+	{
+		PerceptronLink testLink = new PerceptronLink(mockP, mockP, 0);
+		testLinks.addLink(testLink);
+	}
 	
 	@Test
-	public void getAssociatedErrorNoLinks() {
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		
-		final double error = testLink.getAssociatedError();
+	public void getTotalErrorCalculatesCorrectlyWithNoLinks()
+	{
+		final double error = testLinks.getTotalError();
 		final double expectedError = 0;
 		assertEquals(expectedError, error, DELTA);
 	}
 	
 	@Test
-	public void getAssociatedErrorSingleLink()
+	public void getTotalErrorCalculateCorrectlyWithLinks()
 	{
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		testLink.addLink(new MockPerceptron());
+		PerceptronLink link1 = new PerceptronLink(sourceP, mockP, 0.9);
+		PerceptronLink link2 = new PerceptronLink(sourceP, mockP, 0.3);
 		
-		final double error = testLink.getAssociatedError();
-		final double expectedError = 0.5;
-		assertEquals(expectedError, error, DELTA);
-	}
-	
-	@Test
-	public void getAssociatedErrorMultipleLink()
-	{
-		OutputLink testLink = new OutputLink(new MockWeightGenerator());
-		for(int i = 0; i < 3; i++)
-		{
-			testLink.addLink(new MockPerceptron());
-		}
+		testLinks.addLink(link1);
+		testLinks.addLink(link2);
 		
-		final double error = testLink.getAssociatedError();
-		final double expectedError = 1.5;
-		assertEquals(expectedError, error, DELTA);
+		final double expectedError = 0.6;
+		assertEquals(expectedError, testLinks.getTotalError(), DELTA);
 	}
 
 }

--- a/OutputLinkTest.java
+++ b/OutputLinkTest.java
@@ -43,7 +43,7 @@ public class OutputLinkTest {
 	@Test
 	public void getTotalErrorCalculatesCorrectlyWithNoLinks()
 	{
-		final double error = testLinks.getTotalError();
+		final double error = testLinks.totalError();
 		final double expectedError = 0;
 		assertEquals(expectedError, error, DELTA);
 	}
@@ -58,7 +58,7 @@ public class OutputLinkTest {
 		testLinks.addLink(link2);
 		
 		final double expectedError = 0.6;
-		assertEquals(expectedError, testLinks.getTotalError(), DELTA);
+		assertEquals(expectedError, testLinks.totalError(), DELTA);
 	}
 
 }

--- a/OutputPerceptronTest.java
+++ b/OutputPerceptronTest.java
@@ -9,21 +9,23 @@ import neuralNetwork.WeightGenerator;
 
 public class OutputPerceptronTest {
 
-	final double DELTA = 0.001;
+	private final double DELTA = 0.001;
+	private final WeightGenerator mockGen = new MockWeightGenerator();
+	private final MockPerceptron mockP = new MockPerceptron();
 	
-	final WeightGenerator mockGen = new MockWeightGenerator();
-	
-	OutputPerceptron testP;
+	private OutputPerceptron testP;
 	
 	@Before
 	public void setup()
 	{
 		testP = new OutputPerceptron(mockGen);
-		PerceptronLink link1 = new PerceptronLink(new MockPerceptron(), testP, 1);
-		PerceptronLink link2 = new PerceptronLink(new MockPerceptron(), testP, 1);
+		PerceptronLink link1 = new PerceptronLink(mockP, testP, 1);
+		PerceptronLink link2 = new PerceptronLink(mockP, testP, 1);
 		testP.addInputLink(link1);
 		testP.addInputLink(link2);
+		testP.setExpectedOutput(1);
 		testP.activate();
+		testP.calculateError();
 	}
 	
 	@Test
@@ -36,10 +38,6 @@ public class OutputPerceptronTest {
 	@Test
 	public void calculateErrorCorrectlySetsError()
 	{
-		final double trainingExpectedOutput = 1.0;
-		testP.setExpectedOutput(trainingExpectedOutput);
-		testP.calculateError();
-		
 		final double expectedOutput = 0.119203;
 		assertEquals(expectedOutput, testP.error(), DELTA);
 	}
@@ -47,14 +45,22 @@ public class OutputPerceptronTest {
 	@Test
 	public void adjustToErrorCorrectlyUpdatesInputs()
 	{
-		final double trainingExpectedOutput = 1.0;
-		testP.setExpectedOutput(trainingExpectedOutput);
-		testP.calculateError();
 		testP.adjustToError();
 		testP.activate();
 		
 		final double expectedOutput = 0.8829842;
 		assertEquals(expectedOutput, testP.output(), DELTA);
+	}
+	
+	@Test
+	public void addOutputLinkDoesNothing()
+	{
+		PerceptronLink outputLink = new PerceptronLink(testP, mockP, 1);
+		testP.addOutputLink(outputLink);
+		// Reassert previous tests for same expected results.
+		activateProducesCorrectlySetsOutput();
+		calculateErrorCorrectlySetsError();
+		adjustToErrorCorrectlyUpdatesInputs();
 	}
 	
 	@Test (expected = IllegalArgumentException.class)

--- a/OutputPerceptronTest.java
+++ b/OutputPerceptronTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import neuralNetwork.OutputPerceptron;
+import neuralNetwork.PerceptronLink;
 import neuralNetwork.WeightGenerator;
 
 public class OutputPerceptronTest {
@@ -18,8 +19,10 @@ public class OutputPerceptronTest {
 	public void setup()
 	{
 		testP = new OutputPerceptron(mockGen);
-		testP.addInput(new MockPerceptron());
-		testP.addInput(new MockPerceptron());
+		PerceptronLink link1 = new PerceptronLink(new MockPerceptron(), testP, 1);
+		PerceptronLink link2 = new PerceptronLink(new MockPerceptron(), testP, 1);
+		testP.addInputLink(link1);
+		testP.addInputLink(link2);
 		testP.activate();
 	}
 	
@@ -63,7 +66,7 @@ public class OutputPerceptronTest {
 	@Test (expected = IllegalArgumentException.class)
 	public void addInputHandlesNullInput()
 	{
-		testP.addInput(null);
+		testP.addInputLink(null);
 	}
 
 }

--- a/PerceptronLinkTest.java
+++ b/PerceptronLinkTest.java
@@ -1,0 +1,77 @@
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import neuralNetwork.Perceptron;
+import neuralNetwork.PerceptronLink;
+import neuralNetwork.WeightGenerator;
+
+public class PerceptronLinkTest {
+
+	private final Perceptron mockFrom = new MockPerceptron();
+	private final Perceptron mockTo = new MockPerceptron();
+	private final double DELTA = 0.001;
+	
+	private PerceptronLink testLink;
+	
+	@Before
+	public void setUp()
+	{
+		testLink = new PerceptronLink(mockFrom, mockTo, 0.5);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNullFromPerceptron() {
+		testLink = new PerceptronLink(null, mockTo, 1);
+	}
+	
+	@Test (expected = IllegalArgumentException.class)
+	public void constructorHandlesNullToPerceptron() {
+		testLink = new PerceptronLink(mockFrom, null, 1);
+	}
+	
+	@Test
+	public void constructorHandlesZero() {
+		testLink = new PerceptronLink(mockFrom, mockTo, 0);
+	}
+	
+	@Test
+	public void fromReturnsCorrectPerceptron()
+	{
+		assertEquals(mockFrom, testLink.from());
+	}
+	
+	@Test
+	public void toReturnsCorrectPerceptron()
+	{
+		assertEquals(mockTo, testLink.to());
+	}
+	
+	@Test
+	public void weightedOutputReturnsCorrectValue()
+	{
+		final double expectedOutput = 0.25;
+		assertEquals(expectedOutput, testLink.weightedOutput(), DELTA);
+	}
+	
+	@Test
+	public void weightedErrorReturnsCorrectValue()
+	{
+		final double expectedError = 0.25;
+		assertEquals(expectedError, testLink.weightedError(), DELTA);
+	}
+	
+	@Test
+	public void updateWeightByCorrectlyModfiesWeight()
+	{
+		final double updateAmount = 0.1;
+		testLink.updateWeightBy(updateAmount);
+		
+		final double expectedOutput = 0.3;
+		assertEquals(expectedOutput, testLink.weightedOutput(), DELTA);
+		final double expectedError = 0.3;
+		assertEquals(expectedError, testLink.weightedError(), DELTA);
+	}
+
+}

--- a/TestSuite.java
+++ b/TestSuite.java
@@ -14,6 +14,7 @@ import org.junit.runners.Suite;
    OutputPerceptronTest.class,
    InputOutputPerceptronIntegrationTest.class,
    InputHiddenPerceptronIntegrationTest.class,
+   HiddenOutputPerceptronIntegrationTest.class,
    
    InputLinksTest.class,
    OutputLinkTest.class,

--- a/TestSuite.java
+++ b/TestSuite.java
@@ -12,6 +12,7 @@ import org.junit.runners.Suite;
    InputPerceptronTest.class,
    HiddenPerceptronTest.class,
    OutputPerceptronTest.class,
+   InputOutputPerceptronIntegrationTest.class,
    
    InputLinksTest.class,
    OutputLinkTest.class,

--- a/TestSuite.java
+++ b/TestSuite.java
@@ -13,6 +13,7 @@ import org.junit.runners.Suite;
    HiddenPerceptronTest.class,
    OutputPerceptronTest.class,
    InputOutputPerceptronIntegrationTest.class,
+   InputHiddenPerceptronIntegrationTest.class,
    
    InputLinksTest.class,
    OutputLinkTest.class,

--- a/TestSuite.java
+++ b/TestSuite.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite;
    InputOutputPerceptronIntegrationTest.class,
    InputHiddenPerceptronIntegrationTest.class,
    HiddenOutputPerceptronIntegrationTest.class,
+   HiddenHiddenPerceptronIntegrationTest.class,
    
    InputLinksTest.class,
    OutputLinkTest.class,

--- a/TestSuite.java
+++ b/TestSuite.java
@@ -12,6 +12,7 @@ import org.junit.runners.Suite;
    InputPerceptronTest.class,
    HiddenPerceptronTest.class,
    OutputPerceptronTest.class,
+   
    InputOutputPerceptronIntegrationTest.class,
    InputHiddenPerceptronIntegrationTest.class,
    HiddenOutputPerceptronIntegrationTest.class,

--- a/neuralNetwork/.gitignore
+++ b/neuralNetwork/.gitignore
@@ -17,3 +17,4 @@
 /Link.class
 /HiddenLayer.class
 /HiddenLayerTest.class
+/PerceptronLink.class

--- a/neuralNetwork/BiasPerceptron.java
+++ b/neuralNetwork/BiasPerceptron.java
@@ -24,4 +24,10 @@ public class BiasPerceptron implements Perceptron {
 	public void calculateError() {
 	}
 
+	@Override
+	public void addInputLink(PerceptronLink l) {}
+
+	@Override
+	public void addOutputLink(PerceptronLink l) {}
+
 }

--- a/neuralNetwork/HiddenLayer.java
+++ b/neuralNetwork/HiddenLayer.java
@@ -8,6 +8,7 @@ public class HiddenLayer implements NetworkLayer {
 	private HiddenPerceptron[] perceptrons;
 	private List<NetworkLayer> previousLayers;
 	private List<NetworkLayer> nextLayers;
+	private final WeightGenerator weightGen;
 	
 	public HiddenLayer(int size, WeightGenerator wg)
 	{
@@ -27,6 +28,7 @@ public class HiddenLayer implements NetworkLayer {
 		}
 		previousLayers = new ArrayList<NetworkLayer>();
 		nextLayers = new ArrayList<NetworkLayer>();
+		weightGen = wg;
 	}
 	
 	@Override
@@ -58,28 +60,8 @@ public class HiddenLayer implements NetworkLayer {
 		return perceptrons;
 	}
 	
-	public void addNextLayer(NetworkLayer next)
-	{
-		if(next == null)
-		{
-			throw new IllegalArgumentException("Cannot add a null previous network layer to a hidden layer.");
-		}
-		nextLayers.add(next);
-		for(HiddenPerceptron hiddenP : perceptrons)
-		{
-			for(Perceptron outputP : next.perceptrons())
-			{
-				hiddenP.addOutputLink(outputP);
-			}
-		}
-	}
-	
-	public List<NetworkLayer> nextLayers()
-	{
-		return nextLayers;
-	}
-	
-	public void addPreviousLayer(NetworkLayer prev)
+	@Override
+	public void appendTo(NetworkLayer prev)
 	{
 		if(prev == null)
 		{
@@ -90,7 +72,9 @@ public class HiddenLayer implements NetworkLayer {
 		{
 			for(Perceptron inputP : prev.perceptrons())
 			{
-				hiddenP.addInputLink(inputP);
+				PerceptronLink appendingLink = new PerceptronLink(inputP, hiddenP, weightGen.nextWeight());
+				hiddenP.addInputLink(appendingLink);
+				inputP.addInputLink(appendingLink);
 			}
 		}
 	}

--- a/neuralNetwork/HiddenLayer.java
+++ b/neuralNetwork/HiddenLayer.java
@@ -1,13 +1,8 @@
 package neuralNetwork;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class HiddenLayer implements NetworkLayer {
 
 	private HiddenPerceptron[] perceptrons;
-	private List<NetworkLayer> previousLayers;
-	private List<NetworkLayer> nextLayers;
 	private final WeightGenerator weightGen;
 	
 	public HiddenLayer(int size, WeightGenerator wg)
@@ -26,8 +21,6 @@ public class HiddenLayer implements NetworkLayer {
 		{
 			perceptrons[i] = new HiddenPerceptron(wg);
 		}
-		previousLayers = new ArrayList<NetworkLayer>();
-		nextLayers = new ArrayList<NetworkLayer>();
 		weightGen = wg;
 	}
 	
@@ -67,7 +60,6 @@ public class HiddenLayer implements NetworkLayer {
 		{
 			throw new IllegalArgumentException("Cannot add a null previous network layer to a hidden layer.");
 		}
-		previousLayers.add(prev);
 		for(HiddenPerceptron hiddenP : perceptrons)
 		{
 			for(Perceptron inputP : prev.perceptrons())
@@ -77,11 +69,6 @@ public class HiddenLayer implements NetworkLayer {
 				inputP.addInputLink(appendingLink);
 			}
 		}
-	}
-	
-	public List<NetworkLayer> previousLayers()
-	{
-		return previousLayers;
 	}
 
 }

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -21,7 +21,7 @@ public class HiddenPerceptron implements Perceptron
 		{
 			throw new IllegalArgumentException("Cannot have a null weight generator.");
 		}
-		inputLinks = new InputLinks(wg);
+		inputLinks = new InputLinks(this, wg);
 		outputLinks = new OutputLink(this);
 	}
 
@@ -58,13 +58,13 @@ public class HiddenPerceptron implements Perceptron
 		return error;
 	}
 	
-	public void addInputLink(Perceptron p)
+	public void addInputLink(PerceptronLink l)
 	{
-		if(p == null)
+		if(l == null)
 		{
 			throw new IllegalArgumentException("Cannot add input from a null.");
 		}
-		inputLinks.addLink(p);
+		inputLinks.addLink(l);
 	}
 	
 	public void addOutputLink(PerceptronLink l)

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -38,7 +38,7 @@ public class HiddenPerceptron implements Perceptron
 	@Override
 	public void calculateError()
 	{
-		error = outputLinks.getAssociatedError();
+		error = outputLinks.getTotalError();
 	}
 	
 	@Override

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -32,13 +32,13 @@ public class HiddenPerceptron implements Perceptron
 	@Override
 	public void activate()
 	{
-		output = Perceptron.activationFunction(inputLinks.inputValue());
+		output = Perceptron.activationFunction(inputLinks.totalInput());
 	}
 	
 	@Override
 	public void calculateError()
 	{
-		error = outputLinks.getTotalError();
+		error = outputLinks.totalError();
 	}
 	
 	@Override
@@ -64,7 +64,7 @@ public class HiddenPerceptron implements Perceptron
 		{
 			throw new IllegalArgumentException("Cannot add input from a null.");
 		}
-		inputLinks.addLinkFrom(p);
+		inputLinks.addLink(p);
 	}
 	
 	public void addOutputLink(PerceptronLink l)

--- a/neuralNetwork/HiddenPerceptron.java
+++ b/neuralNetwork/HiddenPerceptron.java
@@ -22,7 +22,7 @@ public class HiddenPerceptron implements Perceptron
 			throw new IllegalArgumentException("Cannot have a null weight generator.");
 		}
 		inputLinks = new InputLinks(wg);
-		outputLinks = new OutputLink(wg);
+		outputLinks = new OutputLink(this);
 	}
 
 	/*
@@ -67,12 +67,12 @@ public class HiddenPerceptron implements Perceptron
 		inputLinks.addLinkFrom(p);
 	}
 	
-	public void addOutputLink(Perceptron p)
+	public void addOutputLink(PerceptronLink l)
 	{
-		if(p == null)
+		if(l == null)
 		{
 			throw new IllegalArgumentException("Cannot add output to a null.");
 		}
-		outputLinks.addLink(p);
+		outputLinks.addLink(l);
 	}
 }

--- a/neuralNetwork/InputLayer.java
+++ b/neuralNetwork/InputLayer.java
@@ -93,5 +93,11 @@ public class InputLayer implements NetworkLayer{
 	{
 		return nextLayers;
 	}
+
+	/*
+	 * Input layers only care about provided inputs, not other network layers.
+	 */
+	@Override
+	public void appendTo(NetworkLayer l) {}
 	
 }

--- a/neuralNetwork/InputPerceptron.java
+++ b/neuralNetwork/InputPerceptron.java
@@ -6,22 +6,17 @@ package neuralNetwork;
  * a network.
  */
 public class InputPerceptron implements Perceptron {
-
-	private double input;
-	private double output;
 	
-	public InputPerceptron() {
-		
-	}
+	private double output;
 
 	@Override
 	public void activate() {
-		output = input;
+		// Do nothing - output is only changed by setting input
 	}
 
 	@Override
 	public void adjustToError() {
-		// do nothing
+		// Do nothing
 	}
 
 	@Override
@@ -35,15 +30,25 @@ public class InputPerceptron implements Perceptron {
 	{
 		return 0;
 	}
-	
-	public void setInput(double input)
-	{
-		this.input = input;
-	}
 
 	@Override
 	public void calculateError() {
-		// do nothing
+		// Do nothing
+	}
+
+	@Override
+	public void addInputLink(PerceptronLink l) {
+		// Do nothing
+	}
+
+	@Override
+	public void addOutputLink(PerceptronLink l) {
+		// Do nothing
+	}
+	
+	public void setInput(double input)
+	{
+		this.output = input;
 	}
 
 }

--- a/neuralNetwork/NetworkLayer.java
+++ b/neuralNetwork/NetworkLayer.java
@@ -28,6 +28,15 @@ public interface NetworkLayer {
 	public void adjustToError();
 	
 	/*
+	 * Appends this network layer to another layer.
+	 * The outputs of the other layer are wired to this
+	 * network, and this network's inputs are wired to
+	 * the previous layer. A layer can be appended to
+	 * more than one layer.
+	 */
+	public void appendTo(NetworkLayer l);
+	
+	/*
 	 * 
 	 */
 	public Perceptron[] perceptrons();

--- a/neuralNetwork/OutputLayer.java
+++ b/neuralNetwork/OutputLayer.java
@@ -70,7 +70,7 @@ public class OutputLayer implements NetworkLayer {
 		{
 			for(Perceptron inputP : newInputs)
 			{
-				p.addInput(inputP);
+				p.addInputLink(inputP);
 			}
 		}
 	}

--- a/neuralNetwork/OutputLayer.java
+++ b/neuralNetwork/OutputLayer.java
@@ -58,7 +58,7 @@ public class OutputLayer implements NetworkLayer {
 		}
 	}
 	
-	public void addPreviousLayer(NetworkLayer prev)
+	public void appendTo(NetworkLayer prev)
 	{
 		if(prev == null)
 		{

--- a/neuralNetwork/OutputLayer.java
+++ b/neuralNetwork/OutputLayer.java
@@ -11,8 +11,8 @@ public class OutputLayer implements NetworkLayer {
 	 * calculations and feeding the output to the neural network.
 	 */
 	private OutputPerceptron[] perceptrons;
-	
 	private List<NetworkLayer> previousLayers;
+	private final WeightGenerator weightGen;
 	
 	public OutputLayer(int size, WeightGenerator wg)
 	{
@@ -31,6 +31,7 @@ public class OutputLayer implements NetworkLayer {
 			perceptrons[i] = new OutputPerceptron(wg);
 		}
 		previousLayers = new ArrayList<NetworkLayer>();
+		weightGen = wg;
 	}
 	
 	@Override
@@ -70,7 +71,9 @@ public class OutputLayer implements NetworkLayer {
 		{
 			for(Perceptron inputP : newInputs)
 			{
-				p.addInputLink(inputP);
+				PerceptronLink appendingLink = new PerceptronLink(inputP, p, weightGen.nextWeight());
+				p.addInputLink(appendingLink);
+				inputP.addOutputLink(appendingLink);
 			}
 		}
 	}

--- a/neuralNetwork/OutputLink.java
+++ b/neuralNetwork/OutputLink.java
@@ -10,28 +10,28 @@ import java.util.ArrayList;
  */
 public class OutputLink {
 
-	private WeightGenerator weightGen;
-	private ArrayList<Perceptron> outputs;
-	private ArrayList<Double> weights;
-	private int size;
+	private Perceptron source;
+	private ArrayList<PerceptronLink> links;
 	
-	public OutputLink(WeightGenerator wg)
+	public OutputLink(Perceptron source)
 	{
-		weightGen = wg;
-		outputs = new ArrayList<Perceptron>();
-		weights = new ArrayList<Double>();
-		size = 0;
+		if(source == null)
+		{
+			throw new IllegalArgumentException("Cannot have a null source.");
+		}
+		this.source = source;
+		links = new ArrayList<PerceptronLink>();
 	}
 	
 	/*
 	 * Returns the total error associated with these links.
 	 */
-	public double getAssociatedError()
+	public double getTotalError()
 	{
 		double error = 0;
-		for(int i = 0; i < size; i++)
+		for(PerceptronLink l : links)
 		{
-			error += outputs.get(i).error() * weights.get(i);
+			error += l.weightedError();
 		}
 		return error;
 	}
@@ -39,11 +39,17 @@ public class OutputLink {
 	/*
 	 * Introduces a new link to the OutputLink.
 	 */
-	public void addLink(Perceptron newOutput)
+	public void addLink(PerceptronLink newOutputLink)
 	{
-		outputs.add(newOutput);
-		weights.add(weightGen.nextWeight());
-		size++;
+		if(newOutputLink == null)
+		{
+			throw new IllegalArgumentException("Cannot add a null link.");
+		}
+		if(newOutputLink.from() != source)
+		{
+			throw new IllegalArgumentException("Cannot add a link from a different source.");
+		}
+		links.add(newOutputLink);
 	}
 	
 }

--- a/neuralNetwork/OutputLink.java
+++ b/neuralNetwork/OutputLink.java
@@ -26,7 +26,7 @@ public class OutputLink {
 	/*
 	 * Returns the total error associated with these links.
 	 */
-	public double getTotalError()
+	public double totalError()
 	{
 		double error = 0;
 		for(PerceptronLink l : links)

--- a/neuralNetwork/OutputPerceptron.java
+++ b/neuralNetwork/OutputPerceptron.java
@@ -52,11 +52,7 @@ public class OutputPerceptron implements Perceptron {
 		return error;
 	}
 	
-	public void setExpectedOutput(double newExpectedOutput)
-	{
-		expectedOutput = newExpectedOutput;
-	}
-	
+	@Override
 	public void addInputLink(PerceptronLink l)
 	{
 		if(l == null)
@@ -64,6 +60,14 @@ public class OutputPerceptron implements Perceptron {
 			throw new IllegalArgumentException("Cannot add a null input.");
 		}
 		inputLinks.addLink(l);
+	}
+	
+	@Override
+	public void addOutputLink(PerceptronLink l) {};
+	
+	public void setExpectedOutput(double newExpectedOutput)
+	{
+		expectedOutput = newExpectedOutput;
 	}
 	
 

--- a/neuralNetwork/OutputPerceptron.java
+++ b/neuralNetwork/OutputPerceptron.java
@@ -25,7 +25,7 @@ public class OutputPerceptron implements Perceptron {
 	@Override
 	public void activate() 
 	{
-		output = Perceptron.activationFunction(inputLinks.inputValue());
+		output = Perceptron.activationFunction(inputLinks.totalInput());
 	}
 	
 	@Override
@@ -63,7 +63,7 @@ public class OutputPerceptron implements Perceptron {
 		{
 			throw new IllegalArgumentException("Cannot add a null input.");
 		}
-		inputLinks.addLinkFrom(p);
+		inputLinks.addLink(p);
 	}
 	
 

--- a/neuralNetwork/OutputPerceptron.java
+++ b/neuralNetwork/OutputPerceptron.java
@@ -19,7 +19,7 @@ public class OutputPerceptron implements Perceptron {
 		{
 			throw new IllegalArgumentException("Cannot have a null weight generator.");
 		}
-		inputLinks = new InputLinks(wg);
+		inputLinks = new InputLinks(this, wg);
 	}
 
 	@Override
@@ -57,13 +57,13 @@ public class OutputPerceptron implements Perceptron {
 		expectedOutput = newExpectedOutput;
 	}
 	
-	public void addInput(Perceptron p)
+	public void addInputLink(PerceptronLink l)
 	{
-		if(p == null)
+		if(l == null)
 		{
 			throw new IllegalArgumentException("Cannot add a null input.");
 		}
-		inputLinks.addLink(p);
+		inputLinks.addLink(l);
 	}
 	
 

--- a/neuralNetwork/Perceptron.java
+++ b/neuralNetwork/Perceptron.java
@@ -34,6 +34,18 @@ public interface Perceptron {
 	public double error();
 	
 	/*
+	 * Links the perceptron's input to another perceptron's output
+	 * with a PerceptronLink.
+	 */
+	public void addInputLink(PerceptronLink l);
+	
+	/*
+	 * Links the perceptron's output to another perceptron's input
+	 * with a PerceptronLink.
+	 */
+	public void addOutputLink(PerceptronLink l);
+	
+	/*
 	 * Logistical activation function shared amongst all
 	 * perceptrons.
 	 */

--- a/neuralNetwork/PerceptronLink.java
+++ b/neuralNetwork/PerceptronLink.java
@@ -34,12 +34,12 @@ public class PerceptronLink {
 	
 	public double weightedOutput()
 	{
-		return weight * to.output();
+		return weight * from.output();
 	}
 	
 	public double weightedError()
 	{
-		return weight * from.error();
+		return weight * to.error();
 	}
 	
 }

--- a/neuralNetwork/PerceptronLink.java
+++ b/neuralNetwork/PerceptronLink.java
@@ -1,0 +1,45 @@
+package neuralNetwork;
+
+public class PerceptronLink {
+
+	private Perceptron from;
+	private Perceptron to;
+	private double weight;
+	
+	public PerceptronLink(Perceptron from, Perceptron to, double initialWeight)
+	{
+		if(from == null || to == null)
+		{
+			throw new IllegalArgumentException("Cannot create a link with a null Perceptron.");
+		}
+		this.from = from;
+		this.to = to;
+		weight = initialWeight;
+	}
+	
+	public void updateWeightBy(double amount)
+	{
+		weight += amount;
+	}
+	
+	public Perceptron from()
+	{
+		return from;
+	}
+	
+	public Perceptron to()
+	{
+		return to;
+	}
+	
+	public double weightedOutput()
+	{
+		return weight * to.output();
+	}
+	
+	public double weightedError()
+	{
+		return weight * from.error();
+	}
+	
+}


### PR DESCRIPTION
Modified Perceptron interface, Input/Output link implementations to fix perceptron errors that came up during integration tests. Integration tests for input-output, input-hidden, hidden-output, and hidden-hidden perceptrons were created. Errors in NetworkLayer implementations due to change in Perceptron interface were fixed.
